### PR TITLE
Update Dockerfile - removed missing php ext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,27 +12,22 @@ RUN apk --no-cache add \
     php81-calendar \
     php81-ctype \
     php81-curl \
-    php81-date \
     php81-dom \
     php81-exif \
     php81-fileinfo \
-    php81-filter \
     php81-ftp \
     php81-gd \
     php81-gettext \
-    php81-hash \
     php81-iconv \
     php81-imap \
     php81-intl \
     php81-json \
     php81-ldap \
-    php81-libxml \
     php81-mbstring \
     php81-mysqli \
     php81-mysqlnd \
     php81-openssl \
     php81-pcntl \
-    php81-pcre \
     php81-pdo \
     php81-pdo_mysql \
     php81-pdo_pgsql \
@@ -40,14 +35,11 @@ RUN apk --no-cache add \
     php81-pgsql \
     php81-phar \
     php81-posix \
-    php81-readline \
-    php81-reflection \
     php81-session \
     php81-simplexml \
     php81-soap \
     php81-sockets \
     php81-sodium \
-    php81-spl \
     php81-sqlite3 \
     php81-tokenizer \
     php81-xml \


### PR DESCRIPTION
removed missing php81-xxx, which are not available on apline